### PR TITLE
Feat: Restore item stock on invoice deletion

### DIFF
--- a/app/Observers/InvoiceObserver.php
+++ b/app/Observers/InvoiceObserver.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Invoice;
+use App\Models\Item; // Make sure Item model is imported
+
+class InvoiceObserver
+{
+    /**
+     * Handle the Invoice "deleting" event.
+     *
+     * @param  \App\Models\Invoice  $invoice
+     * @return void
+     */
+    public function deleting(Invoice $invoice)
+    {
+        // Iterate through each item associated with the invoice
+        foreach ($invoice->items as $itemPivot) {
+            // $itemPivot is an instance of Item, with pivot data loaded
+            // Access pivot data like quantity: $itemPivot->pivot->quantity
+            $itemModel = Item::find($itemPivot->id); // Get a fresh instance of the item to be safe
+            if ($itemModel) {
+                $quantityToRestore = $itemPivot->pivot->quantity;
+                $itemModel->stock += $quantityToRestore;
+                $itemModel->save();
+            }
+        }
+    }
+
+    /**
+     * Handle the Invoice "created" event.
+     *
+     * @param  \App\Models\Invoice  $invoice
+     * @return void
+     */
+    public function created(Invoice $invoice)
+    {
+        //
+    }
+
+    /**
+     * Handle the Invoice "updated" event.
+     *
+     * @param  \App\Models\Invoice  $invoice
+     * @return void
+     */
+    public function updated(Invoice $invoice)
+    {
+        //
+    }
+
+    /**
+     * Handle the Invoice "deleted" event.
+     *
+     * @param  \App\Models\Invoice  $invoice
+     * @return void
+     */
+    public function deleted(Invoice $invoice)
+    {
+        //
+    }
+
+    /**
+     * Handle the Invoice "restored" event.
+     *
+     * @param  \App\Models\Invoice  $invoice
+     * @return void
+     */
+    public function restored(Invoice $invoice)
+    {
+        //
+    }
+
+    /**
+     * Handle the Invoice "force deleted" event.
+     *
+     * @param  \App\Models\Invoice  $invoice
+     * @return void
+     */
+    public function forceDeleted(Invoice $invoice)
+    {
+        //
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\Invoice;
+use App\Observers\InvoiceObserver;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Invoice::observe(InvoiceObserver::class);
     }
 }


### PR DESCRIPTION
This commit implements functionality to automatically restore item stock quantities when an invoice is deleted.

- Created `InvoiceObserver` with a `deleting` method.
- Within the `deleting` method, the system iterates through all items associated with the invoice being deleted and increments their stock by the quantity recorded in the invoice-item pivot table.
- Registered `InvoiceObserver` in `AppServiceProvider` to listen for Invoice model events.

This ensures that item stock levels are accurately maintained if an invoice is removed from the system.