### PR TITLE
Feat: Implement soft deletes for invoices with stock adjustment

### DIFF
--- a/app/Filament/Resources/InvoiceResource.php
+++ b/app/Filament/Resources/InvoiceResource.php
@@ -20,7 +20,10 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Illuminate\Database\Eloquent\SoftDeletingScope; // Required for soft delete features
+use Filament\Tables\Filters\TrashedFilter; // Required for TrashedFilter
+use Filament\Tables\Actions\ForceDeleteBulkAction; // Required for bulk force delete
+use Filament\Tables\Actions\RestoreBulkAction; // Required for bulk restore
 use Illuminate\Support\Number;
 use Filament\Infolists; // <-- Pastikan ini ada di atas
 use Filament\Infolists\Infolist;
@@ -164,16 +167,29 @@ class InvoiceResource extends Resource
                 Tables\Columns\TextColumn::make('invoice_date')->label('Tanggal Invoice')->date('d M Y')->sortable(),
             ])
             ->filters([
-                //
+                TrashedFilter::make(),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),
-                Tables\Actions\ViewAction::make(), // Tambahkan ViewAction untuk melihat detail
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\DeleteAction::make(), // Will now soft delete
+                Tables\Actions\ForceDeleteAction::make(),
+                Tables\Actions\RestoreAction::make(),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([
-                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\DeleteBulkAction::make(), // Will now soft delete
+                    ForceDeleteBulkAction::make(),
+                    RestoreBulkAction::make(),
                 ]),
+            ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
             ]);
     }
 

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -3,9 +3,12 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes; // Import SoftDeletes
 
 class Invoice extends Model
 {
+    use SoftDeletes; // Use SoftDeletes trait
+
     protected $fillable = ['customer_id', 'vehicle_id', 'invoice_number', 'invoice_date', 'due_date', 'status', 'subtotal', 'discount_type', 'discount_value', 'total_amount', 'terms'];
 
     public function customer()

--- a/app/Observers/InvoiceObserver.php
+++ b/app/Observers/InvoiceObserver.php
@@ -69,7 +69,17 @@ class InvoiceObserver
      */
     public function restored(Invoice $invoice)
     {
-        //
+        // Re-decrement stock for items on the restored invoice
+        foreach ($invoice->items as $itemPivot) {
+            $itemModel = Item::find($itemPivot->id);
+            if ($itemModel) {
+                $quantityToDecrement = $itemPivot->pivot->quantity;
+                $itemModel->stock -= $quantityToDecrement;
+                $itemModel->save();
+                // Consider adding a check here if stock would go negative and how to handle it,
+                // though for now, we'll assume it's allowed or handled elsewhere.
+            }
+        }
     }
 
     /**

--- a/database/migrations/2025_06_08_180000_add_deleted_at_to_invoices_table.php
+++ b/database/migrations/2025_06_08_180000_add_deleted_at_to_invoices_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};


### PR DESCRIPTION
This commit introduces soft delete functionality for invoices and ensures that item stock levels are managed correctly during soft delete and restore operations.

Key changes:
- Added a migration for the `deleted_at` column on the `invoices` table.
- Added the `SoftDeletes` trait to the `Invoice` model.
- Updated `InvoiceResource.php`:
    - Added `TrashedFilter` to allow viewing of soft-deleted invoices.
    - Included `ForceDeleteAction`, `RestoreAction`, and their bulk counterparts.
    - Modified `getEloquentQuery()` to work with `TrashedFilter` by removing the global `SoftDeletingScope`.
- Updated `InvoiceObserver.php`:
    - The existing `deleting` method now handles stock restoration when an invoice is soft-deleted.
    - Added logic to the `restored` method to re-decrement item stock when a soft-deleted invoice is restored.

This provides a more robust way to manage invoices, allowing for archival and recovery while maintaining accurate inventory counts.